### PR TITLE
FM-10 Use correct namespace URI in genmodel registration.

### DIFF
--- a/bundles/de.uka.ipd.sdq.featuremodel/plugin.xml
+++ b/bundles/de.uka.ipd.sdq.featuremodel/plugin.xml
@@ -12,7 +12,7 @@
 
   <extension point="org.eclipse.emf.ecore.generated_package">
     <package 
-       uri = "http://sdq.ipd.uka.de/FeatureModel/3.0" 
+       uri = "http://sdq.ipd.uka.de/FeatureModel/2.0" 
        class = "de.uka.ipd.sdq.featuremodel.featuremodelPackage"
        genModel = "model/featuremodel.genmodel" /> 
   </extension>


### PR DESCRIPTION
This PR fixes [FM-10](https://jira.palladio-simulator.com/browse/FM-10).